### PR TITLE
Changing structure of state in Group

### DIFF
--- a/src/back/Group.class.tsx
+++ b/src/back/Group.class.tsx
@@ -13,6 +13,13 @@ interface IDebt{
   amount: Number;
 }
 
+interface IGroup{
+  users: Users;
+  transactions: Transactions;
+  name: String;
+  debts: IDebt[];
+}
+
 class CGroup{
   users: Users;
   transactions: Transactions;
@@ -92,5 +99,5 @@ class CGroup{
 }
 
 
-export type {IDebt};
+export type {IDebt, IGroup, Users};
 export default CGroup;

--- a/src/front/Balances.tsx
+++ b/src/front/Balances.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import CGroup from "./../back/Group.class"
+import CGroup, { IDebt, Users } from "./../back/Group.class"
 
 import "./Balances.css"
 import DebtList from "./DebtList"
 
 interface BalancesProps {
-  group: CGroup
+  users: Users,
+  debts: IDebt[]
 }
  
-const Balances = ({group}: BalancesProps) => {
-  const balances = Object.values(group.users).map((user) => <div key={user.id} className="balance-item"><span>{user.name}</span> <span>{user.balance > 0 ? "+" + user.balance : user.balance}</span></div>)
+const Balances = ({users, debts}: BalancesProps) => {
+  const balances = Object.values(users).map((user) => <div key={user.id} className="balance-item"><span>{user.name}</span> <span>{user.balance > 0 ? "+" + user.balance : user.balance}</span></div>)
   return ( <section className="balance-section">
     {balances}
-    <DebtList debts={group.debts} />
+    <DebtList debts={debts} />
     </section>);
 }
  

--- a/src/front/Group.tsx
+++ b/src/front/Group.tsx
@@ -11,24 +11,37 @@ import groupTest from '../back/main';
 import "./Group.css"
 import NewTransactionForm from "./NewTransactionForm";
 import NewTransaction from './NewTransaction';
+import { TransactionI } from '../back/Transaction.class';
 
 interface GroupProps {
   group: CGroup
 }
 
-const handleAddTransaction = (e: any) => {
-  e.preventDefault()
-  console.log("oui");
-}
- 
+const groupBackEnd = groupTest();
+
 const Group = () => {
-  const [group, setGroup] = useState(groupTest())
+
+  const [groupName, setGroupName] = useState(groupBackEnd.name);
+  const [transactions, setTransactions] = useState(groupBackEnd.transactions);
+  const [users, setUsers] = useState(groupBackEnd.users);
+  const [debts, setDebts] = useState(groupBackEnd.debts);
+  
+  const updateState = () => {
+    setTransactions({...groupBackEnd.transactions})
+    setUsers({...groupBackEnd.users})
+    setDebts([...groupBackEnd.debts])
+  }
+  
+  const handleAddTransaction = (name: String, amount: number, giverId: number,receiverId: number) => {
+    groupBackEnd.addTransaction({id: 10,name, amount, giver: groupBackEnd.users[giverId], receiver: groupBackEnd.users[receiverId]});
+    updateState();
+  }
 
   return (
     <div className="group-section">
-      <TransactionList transactions={group.transactions} groupName={group.name}></TransactionList>
-      <Balances group={group} />
-      <NewTransaction users={Object.values(group.users)} onAddTransaction={handleAddTransaction} />
+      <TransactionList transactions={transactions} groupName={groupName}></TransactionList>
+      <Balances users={users} debts={debts} />
+      <NewTransaction users={Object.values(users)} onAddTransaction={handleAddTransaction} />
     </div>
   );
 }

--- a/src/front/NewTransaction.tsx
+++ b/src/front/NewTransaction.tsx
@@ -11,7 +11,7 @@ interface NewTransactionProps {
  
 const NewTransaction = ({onAddTransaction, users}: NewTransactionProps) => {
   const [isFormDisplayed, setIsFormDisplayed] = useState(true);
-  const [amount, setAmount] = useState(null);
+  const [amount, setAmount] = useState(0);
   const [name, setName] = useState(null);
   const [selectedReceiverId, setSelectedReceiverId] = useState(null);
   const [selectedGiverId, setSelectedGiverId] = useState(null);
@@ -26,7 +26,7 @@ const NewTransaction = ({onAddTransaction, users}: NewTransactionProps) => {
   }
 
   const handleFormChangeAmount = (amount: any) => {
-    setAmount(amount);
+    setAmount(Number(amount));
   }
 
   const handleFormChangeReceiver = (selectedReceiverId: any) => {
@@ -38,10 +38,6 @@ const NewTransaction = ({onAddTransaction, users}: NewTransactionProps) => {
   }
 
   const handleValidate = () => {
-    console.log('Name: ' + name);
-    console.log('Amount: ' + amount);
-    console.log('Give: ' + selectedGiverId);
-    console.log('Receive: ' + selectedReceiverId);
     if(!name || amount == 0 || !selectedGiverId || !selectedReceiverId){
       console.log("Le formulaire n'est pas correctement remplie") //TODO: Handle error
       return;


### PR DESCRIPTION
Firstly, the state was represented by a single object of type CGroup. But updating state of a nested object is not well supported in React, even more with a Class containing method. Thus, I decided to split this object in several objects, the same objects it was containing. It appears to make the sepration between (not yet created) backend and frontend clearer.